### PR TITLE
Improve the startup time and time it takes for vali to start setting weights

### DIFF
--- a/tts_rater/pann.py
+++ b/tts_rater/pann.py
@@ -1,9 +1,9 @@
 import math
-import os
 import pathlib
 
 import librosa
 import numpy as np
+import requests
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -1115,7 +1115,8 @@ class PANNModel:
         if not checkpoint_path.exists():
             checkpoint_path.parent.mkdir(exist_ok=True)
             dl_path = "https://zenodo.org/record/3987831/files/Cnn14_mAP%3D0.431.pth?download=1"
-            os.system('wget -O "{}" "{}"'.format(checkpoint_path, dl_path))
+            with open(checkpoint_path, "wb") as f:
+                f.write(requests.get(dl_path).content)
 
         if device == "cuda" and torch.cuda.is_available():
             self.device = "cuda"


### PR DESCRIPTION
- Instead of downloading all models at the beginning, it is changed to only download models as it is used.
- Reduce the number of models that are being evaluated each iteration to reduce the time between setting weights
- Remove implicit dependency on `wget` by using `requests` library instead
- Fix logging to also log `info` by default.