### PR TITLE
Revert the wait_for_inclusion flag because it isn't supported

### DIFF
--- a/neurons/validator_utils.py
+++ b/neurons/validator_utils.py
@@ -247,7 +247,7 @@ def set_weights_with_err_msg(
                 return success, message, exceptions
 
         except Exception as e:
-            bt.logging.error(f"Error setting weights: {e}")
+            bt.logging.exception(f"Error setting weights: {e}")
             exceptions.append(e)
         finally:
             retries += 1


### PR DESCRIPTION
See e.g., https://github.com/neuralinternet/compute-subnet/pull/46. It seems like the `wait_for_inclusion` flag is not supported yet and will cause issues.