### PR TITLE
p310 patch

### DIFF
--- a/constants/__init__.py
+++ b/constants/__init__.py
@@ -37,7 +37,7 @@ COMPETITION_SCHEDULE: List[CompetitionParameters] = [
 ]
 ORIGINAL_COMPETITION_ID = "p310"
 CONSTANT_ALPHA = 0.1 # prev: 0.2
-timestamp_epsilon = 0.01
+timestamp_epsilon = 0.005
 
 assert math.isclose(sum(x.reward_percentage for x in COMPETITION_SCHEDULE), 1.0)
 

--- a/tts_rater/rater.py
+++ b/tts_rater/rater.py
@@ -390,7 +390,7 @@ def rate_(
     keys = list(norm_dict.keys())
     norm_scores = []
     for ii in range(samples):
-        norm_score = np.sum([norm_dict[k][ii] for k in keys])
+        norm_score = np.prod([norm_dict[k][ii] for k in keys])
         norm_scores.append(norm_score)
 
     return norm_scores, norm_dict


### PR DESCRIPTION
reverse back to `prod` instead of `sum`
lower the penalty for new models