### PR TITLE
Fix winrate computation typo, Change blacklist to use relative difference instead of absolute differences

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -767,7 +767,7 @@ class Validator:
             if sum(scores) > 0.:
                 bt.logging.info(f"Computed model scores for uid {uid_i}. Mean: {np.array(scores).mean()}")
         
-        wins, win_rate = compute_wins(uids, scores_per_uid, self.block)
+        win_rate = compute_wins(uids, scores_per_uid, self.block)
 
         # Update the win rate for the current step.
         if hasattr(self, "temp_win_rate"):

--- a/neurons/validator_utils.py
+++ b/neurons/validator_utils.py
@@ -94,6 +94,7 @@ def compute_wins(
         # Calculate win rate for uid i
         win_rate_1[uid_i] = wins[uid_i] / total_matches if total_matches > 0 else 0
 
+    wins = {uid: 0 for uid in uids}
     win_rate_4 = {uid: 0 for uid in uids}
     for i, uid_i in enumerate(whitelist_uids):
         total_matches = 0
@@ -112,6 +113,7 @@ def compute_wins(
         # Calculate win rate for uid i
         win_rate_4[uid_i] = wins[uid_i] / total_matches if total_matches > 0 else 0
 
+    wins = {uid: 0 for uid in uids}
     win_rate_8 = {uid: 0 for uid in uids}
     for i, uid_i in enumerate(whitelist_uids):
         total_matches = 0
@@ -134,7 +136,7 @@ def compute_wins(
         # Calculate win rate for uid i
         win_rate_8[uid_i] = wins[uid_i] / total_matches if total_matches > 0 else 0
     win_rate = {uid: (win_rate_1[uid] * 0.25 + win_rate_4[uid] * 0.25 + win_rate_8[uid] * 0.5) for uid in uids}
-    return wins, win_rate
+    return win_rate
 
 def adjust_for_vtrust(weights: np.ndarray, consensus: np.ndarray, vtrust_min: float = 0.5):
     """

--- a/neurons/validator_utils.py
+++ b/neurons/validator_utils.py
@@ -55,10 +55,18 @@ def compute_wins(
             if i == j or uid_j in blacklist_uids:
                 continue
             block_j = block[uid_j]
+
+            scores_i = np.asarray(scores_per_uid[uid_i])
+            scores_j = np.asarray(scores_per_uid[uid_j])
+
+            epsilon = 1e-6
+            relative_diff = np.abs(scores_i - scores_j) / (epsilon + np.maximum(np.abs(scores_i), np.abs(scores_j)))
+
             # check if scores are similar...
-            # currently we are chilling to put tolerance to 1e-1
+            # The models are similar if the relative change is smaller than 10%.
             # if the scores are similar, we will blacklist the model with the higher block number
-            if abs(np.asarray(scores_per_uid[uid_i]) - np.asarray(scores_per_uid[uid_j])).max() < 1e-1:
+            relative_change_threshold = 0.1
+            if relative_diff.max() < relative_change_threshold:
                 if block_i < block_j:
                     blacklist_uids.append(uid_j)
                 else:


### PR DESCRIPTION
Using absolute differences for the backlist mechanism results in the sensitivity of blacklisting to depend on the current magnitude of the scores.

For example, if the current score is 0.2, asking for a 0.1 **absolute** difference in the scores amounts to asking for a **50%** increase / decrease in score, which is extremely difficult. On the other hand, if the current score is 0.9, then this becomes a milder requirement of 11% increase / decrease in score.

When the validation criteria updated resulting in different magnitudes of scores for the current models, the resulting threshold for blacklisting will then also need to be updated if we are using **absolute** differences.

Instead, this PR changes the blacklisting mechanism to use **relative** differences instead, which can be seen as automatically choosing the threshold to scale with the current "difficulty".

Also, this fixes a typo with the winrate computation that results in the winrate being greater than 1