### PR TITLE
Fix typo causing winrate to (still) be greater than 1

### DIFF
--- a/neurons/validator_utils.py
+++ b/neurons/validator_utils.py
@@ -124,7 +124,11 @@ def compute_wins(
                 total_matches += 1
         # Calculate win rate for uid i
         win_rate_8[uid_i] = wins[uid_i] / total_matches if total_matches > 0 else 0
-    win_rate = {uid: (win_rate_1[uid] * 0.25 + win_rate_4[uid] * 0.5 + win_rate_8[uid]) for uid in uids}
+
+    weights = {win_rate_1: 0.25, win_rate_4: 0.5, win_rate_8: 1.0}
+    weights_sum = sum(weights.values())
+    weights = {winrate_dict: weight / weights_sum for winrate_dict, weight in weights.items()}
+    win_rate = {uid: sum([win_rate_dict[uid] * weight for win_rate_dict, weight in weights.items()]) for uid in uids}
     return wins, win_rate
 
 def adjust_for_vtrust(weights: np.ndarray, consensus: np.ndarray, vtrust_min: float = 0.5):


### PR DESCRIPTION
The winrate is **still** greater than 1. This is due to a (not sure if intentional) typo from #25, which changed

```python
win_rate = {uid: (win_rate_1[uid] * 0.25 + win_rate_4[uid] * 0.25 + win_rate_8[uid] * 0.5) for uid in uids}
```

to

```python
win_rate = {uid: (win_rate_1[uid] * 0.25 + win_rate_4[uid] * 0.5 + win_rate_8[uid]) for uid in uids}
```

Note that `0.25 + 0.25 + 0.5 = 1`, but `0.25 + 0.5 + 1 = 1.75 > 1`.